### PR TITLE
feat: add starter suggestions setting

### DIFF
--- a/cypress/e2e/builder/main.cy.ts
+++ b/cypress/e2e/builder/main.cy.ts
@@ -50,7 +50,7 @@ describe('Builder View', () => {
     // show default values
     cy.get(buildDataCy(CHATBOT_SETTINGS_SUMMARY_CY))
       .should('contain', 'Graasp Bot')
-      .should('contain', 'The conversation starter is empty');
+      .should('contain', '-');
 
     cy.get(EDIT_SETTINGS_BUTTON).click();
 
@@ -68,7 +68,6 @@ describe('Builder View', () => {
     cy.get(buildDataCy(CHATBOT_SETTINGS_SUMMARY_CY))
       .should('contain', 'Graasp Bot')
       .should('contain', prompt)
-      .should('not.contain', 'The conversation starter is empty')
       .should('contain', cue);
   });
 
@@ -110,11 +109,10 @@ describe('Builder View', () => {
     cy.get(buildDataCy(CHATBOT_SETTINGS_SUMMARY_CY))
       .should('contain', name)
       .should('contain', prompt)
-      .should('not.contain', 'The conversation starter is empty')
       .should('contain', cue);
   });
 
-  it('Show starter suggestions and edit', () => {
+  it.only('Show starter suggestions and edit', () => {
     cy.setUpApi(
       { appSettings: [] },
       {

--- a/cypress/e2e/builder/main.cy.ts
+++ b/cypress/e2e/builder/main.cy.ts
@@ -112,7 +112,7 @@ describe('Builder View', () => {
       .should('contain', cue);
   });
 
-  it.only('Show starter suggestions and edit', () => {
+  it('Show starter suggestions and edit', () => {
     cy.setUpApi(
       { appSettings: [] },
       {

--- a/cypress/e2e/builder/main.cy.ts
+++ b/cypress/e2e/builder/main.cy.ts
@@ -14,6 +14,10 @@ const PROMPT_TEXT_AREA = '[name="Chatbot Prompt"]';
 const CUE_TEXT_AREA = '[name="Conversation Starter"]';
 const CHATBOT_NAME_INPUT = '[name="Chatbot Name"]';
 
+const ADD_STARTER_SUGGESTION_BUTTON = '[title="Add starter suggestion"]';
+const buildStarterSuggestionInput = (idx: number) =>
+  `[name="Starter suggestion number ${idx}"]`;
+
 describe('Builder View', () => {
   it('Results table', () => {
     cy.setUpApi(
@@ -108,5 +112,64 @@ describe('Builder View', () => {
       .should('contain', prompt)
       .should('not.contain', 'The conversation starter is empty')
       .should('contain', cue);
+  });
+
+  it('Show starter suggestions and edit', () => {
+    cy.setUpApi(
+      { appSettings: [] },
+      {
+        context: Context.Builder,
+        permission: PermissionLevel.Admin,
+      },
+    );
+    cy.visit('/');
+
+    cy.get(buildDataCy(TAB_SETTINGS_VIEW_CYPRESS)).click();
+
+    cy.get(EDIT_SETTINGS_BUTTON).click();
+
+    // change prompt
+    const prompt = 'my new prompt';
+    cy.get(PROMPT_TEXT_AREA).clear().type(prompt);
+
+    const newSuggestions = ['Hello', 'Hello1', 'Hello2'];
+
+    // add suggestions
+    newSuggestions.forEach((s, idx) => {
+      cy.get(ADD_STARTER_SUGGESTION_BUTTON).click();
+      cy.get(buildStarterSuggestionInput(idx)).type(s);
+    });
+
+    cy.get(SAVE_SETTINGS_BUTTON).click();
+
+    // show starter suggestions
+    for (const s of newSuggestions) {
+      cy.get(`li:contains('${s}')`).should('be.visible');
+    }
+
+    cy.wait(1000);
+    cy.get(EDIT_SETTINGS_BUTTON).click();
+
+    // edit suggestions
+    const editedSuggestions = ['newHello0', 'newHello1', 'newHello2'];
+    editedSuggestions.forEach((s, idx) => {
+      cy.get(buildStarterSuggestionInput(idx)).clear().type(s);
+    });
+
+    // delete second suggestion
+    cy.get(`[title="Delete suggestion number 1"]`).click();
+
+    // expect remaining suggestions
+    const remainingSuggestions = [editedSuggestions[0], editedSuggestions[2]];
+    for (const s of remainingSuggestions) {
+      cy.get(`[value="${s}"]`).should('be.visible');
+    }
+
+    cy.get(SAVE_SETTINGS_BUTTON).click();
+
+    // show starter suggestions
+    for (const s of remainingSuggestions) {
+      cy.get(`li:contains('${s}')`).should('be.visible');
+    }
   });
 });

--- a/cypress/e2e/player/main.cy.ts
+++ b/cypress/e2e/player/main.cy.ts
@@ -138,4 +138,36 @@ describe('Player View', () => {
     cy.get('#root').should('contain', 'November 18, 2024');
     cy.get('#root').should('contain', 'November 18, 2025');
   });
+
+  it.only('Use a starter suggestion', () => {
+    cy.setUpApi(
+      {
+        appData: [],
+        appSettings: [MOCK_APP_SETTING],
+      },
+      {
+        context: Context.Player,
+        permission: PermissionLevel.Write,
+      },
+    );
+    cy.visit('/');
+
+    const suggestion = MOCK_APP_SETTING.data.starterSuggestions[0];
+    // click suggestion
+    cy.get(`button:contains("${suggestion}")`).click();
+
+    // expect user message
+    cy.get(buildDataCy(buildCommentContainerDataCy('2'))).should(
+      'contain',
+      suggestion,
+    );
+
+    // expect chatbot message
+    cy.get(buildDataCy(buildCommentContainerDataCy('3'))).should(
+      'contain',
+      'i am a bot', // default return value of the mocked chatbot
+    );
+
+    cy.get(`button:contains("${suggestion}")`).should('not.be.visible');
+  });
 });

--- a/cypress/e2e/player/main.cy.ts
+++ b/cypress/e2e/player/main.cy.ts
@@ -37,7 +37,7 @@ describe('Player View', () => {
     cy.visit('/');
 
     // expect previously saved app data
-    const previousAppData = defaultAppData[0];
+    const [previousAppData] = defaultAppData;
     cy.get(buildDataCy(buildCommentContainerDataCy(previousAppData.id))).should(
       'contain',
       previousAppData.data.content,
@@ -152,7 +152,7 @@ describe('Player View', () => {
     );
     cy.visit('/');
 
-    const suggestion = MOCK_APP_SETTING.data.starterSuggestions[0];
+    const [suggestion] = MOCK_APP_SETTING.data.starterSuggestions;
     // click suggestion
     cy.get(`button:contains("${suggestion}")`).click();
 

--- a/cypress/e2e/player/main.cy.ts
+++ b/cypress/e2e/player/main.cy.ts
@@ -139,7 +139,7 @@ describe('Player View', () => {
     cy.get('#root').should('contain', 'November 18, 2025');
   });
 
-  it.only('Use a starter suggestion', () => {
+  it('Use a starter suggestion', () => {
     cy.setUpApi(
       {
         appData: [],
@@ -153,6 +153,7 @@ describe('Player View', () => {
     cy.visit('/');
 
     const [suggestion] = MOCK_APP_SETTING.data.starterSuggestions;
+
     // click suggestion
     cy.get(`button:contains("${suggestion}")`).click();
 
@@ -168,6 +169,6 @@ describe('Player View', () => {
       'i am a bot', // default return value of the mocked chatbot
     );
 
-    cy.get(`button:contains("${suggestion}")`).should('not.be.visible');
+    cy.get('button').should('not.contain', suggestion);
   });
 });

--- a/cypress/fixtures/mockSettings.ts
+++ b/cypress/fixtures/mockSettings.ts
@@ -12,5 +12,6 @@ export const MOCK_APP_SETTING = {
     chatbotCue: 'cue',
     chatbotName: 'name',
     initialPrompt: 'prompt',
+    starterSuggestions: ['Can you spell it for me?', 'Can you explain this?'],
   },
 };

--- a/src/config/appActions.ts
+++ b/src/config/appActions.ts
@@ -6,4 +6,5 @@ export const AppActionsType = {
   Reply: 'reply_comment',
   // chatbot actions
   AskChatbot: 'ask_chatbot',
+  UseStarter: 'use_starter',
 } as const;

--- a/src/config/appSetting.ts
+++ b/src/config/appSetting.ts
@@ -9,14 +9,14 @@ export const ChatbotPromptSettingsKeys = {
   InitialPrompt: 'initialPrompt',
   ChatbotCue: 'chatbotCue',
   ChatbotName: 'chatbotName',
-  starterSuggestions: 'starterSuggestions',
+  StarterSuggestions: 'starterSuggestions',
 } as const;
 
 export type ChatbotPromptSettings = {
   [ChatbotPromptSettingsKeys.InitialPrompt]: string;
   [ChatbotPromptSettingsKeys.ChatbotCue]: string;
   [ChatbotPromptSettingsKeys.ChatbotName]: string;
-  [ChatbotPromptSettingsKeys.starterSuggestions]: string[];
+  [ChatbotPromptSettingsKeys.StarterSuggestions]: string[];
   // used to allow access using settings[settingKey] syntax
   // [key: string]: unknown;
 };

--- a/src/config/appSetting.ts
+++ b/src/config/appSetting.ts
@@ -9,12 +9,14 @@ export const ChatbotPromptSettingsKeys = {
   InitialPrompt: 'initialPrompt',
   ChatbotCue: 'chatbotCue',
   ChatbotName: 'chatbotName',
+  starterSuggestions: 'starterSuggestions',
 } as const;
 
 export type ChatbotPromptSettings = {
   [ChatbotPromptSettingsKeys.InitialPrompt]: string;
   [ChatbotPromptSettingsKeys.ChatbotCue]: string;
   [ChatbotPromptSettingsKeys.ChatbotName]: string;
+  [ChatbotPromptSettingsKeys.starterSuggestions]: string[];
   // used to allow access using settings[settingKey] syntax
   // [key: string]: unknown;
 };

--- a/src/langs/en.json
+++ b/src/langs/en.json
@@ -29,12 +29,14 @@
     "CHATBOT_PROMPT_HELPER_LABEL": "In-depth technical description",
     "CHATBOT_PROMPT_HELPER": "This defines the chatbot's personality and how it should behave.",
     "CHATBOT_PROMPT_FORMAT_HELPER": "To describe the initial situation, create an object at the start of the array with 2 keys: 'role' and 'content'. For the initial description the role must be 'system'. Place your description of the initial situation in the 'content' key. Add interaction examples after that. Add one object per message with the role corresponding to either 'assistant' or 'user'.",
+    "CHATBOT_STARTER_SUGGESTIONS_LABEL": "Starter Suggestions",
+    "CHATBOT_STARTER_SUGGESTIONS_EMPTY_MESSAGE": "-",
     "CHATBOT_PROMPT_FORMAT_EXAMPLE": "Here is an example",
     "CHATBOT_PROMPT_API_REFERENCE": "See the API reference",
     "CHATBOT_CUE_LABEL": "Conversation Starter",
     "CHATBOT_STARTER_SUGGESTION_LABEL": "Starter Suggestions",
     "CHATBOT_CUE_HELPER": "This defines the content of the first message of the chatbot. You can change it to better orient the conversation.",
-    "CHATBOT_CUE_EMPTY_MESSAGE": "The conversation starter is empty.",
+    "CHATBOT_CUE_EMPTY_MESSAGE": "-",
     "SAVE_LABEL": "Save",
     "SAVED_LABEL": "Saved",
     "GENERAL_SETTING_TITLE": "General",
@@ -66,6 +68,12 @@
     "CLOSE": "Close",
     "SIGN_OUT_ALERT": "You should be signed in to interact with the chatbot",
     "ANALYTICS_CONVERSATION_MEMBER": "Conversation",
-    "CHATBOT_STARTER_SUGGESTION_HELPER": "This defines suggested messages the user can send at the beginning of the conversation to the chatbot. You can change it to give ideas of interactions."
+    "CHATBOT_STARTER_SUGGESTION_HELPER": "This defines suggested messages the user can send at the beginning of the conversation to the chatbot. You can change it to give ideas of interactions.",
+    "ADD_STARTER_SUGGESTION_BUTTON": "Add",
+    "ADD_STARTER_SUGGESTION_BUTTON_TITLE": "Add starter suggestion",
+    "STARTER_SUGGESTION_NAME": "Starter suggestion number {{nb}}",
+    "DELETE_STARTER_SUGGESTION_BUTTON_TITLE": "Delete suggestion number {{nb}}",
+    "STARTER_SUGGESTION_PLACEHOLDER": "Write a suggestion here",
+    "STARTER_SUGGESTION_PLAYER_BUTTON_ARIA_LABEL": "Ask {{suggestion}}"
   }
 }

--- a/src/langs/en.json
+++ b/src/langs/en.json
@@ -32,6 +32,7 @@
     "CHATBOT_PROMPT_FORMAT_EXAMPLE": "Here is an example",
     "CHATBOT_PROMPT_API_REFERENCE": "See the API reference",
     "CHATBOT_CUE_LABEL": "Conversation Starter",
+    "CHATBOT_STARTER_SUGGESTION_LABEL": "Starter Suggestions",
     "CHATBOT_CUE_HELPER": "This defines the content of the first message of the chatbot. You can change it to better orient the conversation.",
     "CHATBOT_CUE_EMPTY_MESSAGE": "The conversation starter is empty.",
     "SAVE_LABEL": "Save",
@@ -64,6 +65,7 @@
     "CONFIGURE_BUTTON": "Configure",
     "CLOSE": "Close",
     "SIGN_OUT_ALERT": "You should be signed in to interact with the chatbot",
-    "ANALYTICS_CONVERSATION_MEMBER": "Conversation"
+    "ANALYTICS_CONVERSATION_MEMBER": "Conversation",
+    "CHATBOT_STARTER_SUGGESTION_HELPER": "This defines suggested messages the user can send at the beginning of the conversation to the chatbot. You can change it to give ideas of interactions."
   }
 }

--- a/src/modules/analytics/FrequentWords.tsx
+++ b/src/modules/analytics/FrequentWords.tsx
@@ -157,7 +157,7 @@ function FrequentWords({
         >
           <DialogTitle>{t('ANALYTICS_CONVERSATION_MEMBER')}</DialogTitle>
           <DialogContent>
-            <ConversationForUser userId={chatMemberID} />
+            <ConversationForUser accountId={chatMemberID} />
           </DialogContent>
           <DialogActions>
             <Button>{t('CLOSE')}</Button>

--- a/src/modules/comment/Conversation.tsx
+++ b/src/modules/comment/Conversation.tsx
@@ -14,6 +14,7 @@ import { ChatbotPromptSettings } from '@/config/appSetting';
 
 import CommentEditor from '../common/CommentEditor';
 import CommentThread from '../common/CommentThread';
+import { Suggestions } from '../common/Suggestions';
 import { Comment } from '../common/useConversation';
 import ChatbotHeader from './ChatbotHeader';
 import CommentContainer from './CommentContainer';
@@ -25,6 +26,7 @@ function Conversation({
   chatbotAvatar,
   isLoading,
   mode = 'read',
+  suggestions,
 }: Readonly<{
   chatbotPrompt?: ChatbotPromptSettings;
   chatbotAvatar?: Blob;
@@ -32,6 +34,7 @@ function Conversation({
   isLoading?: boolean;
   comments: Comment[];
   mode?: 'read' | 'write';
+  suggestions?: string[];
 }>) {
   const { t } = useTranslation();
 
@@ -56,6 +59,12 @@ function Conversation({
               threadSx={threadSx}
               comments={comments}
             />
+            {suggestions && (
+              <Suggestions
+                suggestions={suggestions}
+                chatbotPrompt={chatbotPrompt}
+              />
+            )}
             {'write' === mode && (
               <CommentEditor chatbotPrompt={chatbotPrompt} />
             )}

--- a/src/modules/comment/ConversationForUser.tsx
+++ b/src/modules/comment/ConversationForUser.tsx
@@ -2,10 +2,11 @@ import { useConversation } from '../common/useConversation';
 import Conversation from './Conversation';
 
 export const ConversationForUser = ({
-  userId,
-}: Readonly<{ userId: string }>) => {
-  const { comments, isLoading, chatbotPrompt, chatbotAvatar } =
-    useConversation(userId);
+  accountId,
+}: Readonly<{ accountId: string }>) => {
+  const { comments, isLoading, chatbotPrompt, chatbotAvatar } = useConversation(
+    { accountId },
+  );
 
   return (
     <Conversation

--- a/src/modules/common/Comment.tsx
+++ b/src/modules/common/Comment.tsx
@@ -57,7 +57,7 @@ export function BotComment({
         pr={10}
       >
         <Stack>
-          <ChatbotAvatar size="small" avatar={avatar} />;
+          <ChatbotAvatar size="small" avatar={avatar} />
         </Stack>
         <Stack sx={{ py: 0 }} alignItems="start" gap={1}>
           <Typography variant="subtitle2">{name}</Typography>

--- a/src/modules/common/CommentEditor.tsx
+++ b/src/modules/common/CommentEditor.tsx
@@ -24,8 +24,7 @@ import {
 } from '@/config/selectors';
 import { SMALL_BORDER_RADIUS } from '@/constants';
 
-import { useAskChatbot } from './useAskChatbot';
-import { useSendMessage } from './useSendMessage';
+import { useSendMessageAndAskChatbot } from './useSendMessageAndAskChatbot';
 
 const TextArea = styled(TextareaAutosize)(({ theme }) => ({
   borderRadius: SMALL_BORDER_RADIUS,
@@ -59,28 +58,10 @@ function CommentEditor({
   const [text, setText] = useState('');
   const [textTooLong, setTextTooLong] = useState('');
 
-  const { generateChatbotAnswer, isLoading: askChatbotLoading } =
-    useAskChatbot(chatbotPrompt);
-  const { sendMessage, isLoading: sendMessageLoading } =
-    useSendMessage(chatbotPrompt);
-
-  const onSendHandler = async (newUserComment: string) => {
-    if (!chatbotPrompt) {
-      throw new Error(
-        "unexpected error, chatbot setting is not present, can't sent to API without it",
-      );
-    }
-
-    try {
-      const userMessage = await sendMessage(newUserComment);
-
-      await generateChatbotAnswer(userMessage.id, newUserComment);
-
-      setText('');
-    } catch (e) {
-      console.error(e);
-    }
-  };
+  const { send, isLoading } = useSendMessageAndAskChatbot({
+    chatbotPrompt,
+    onSend: () => setText(''),
+  });
 
   const handleTextChange = ({
     target: { value },
@@ -118,8 +99,8 @@ function CommentEditor({
           data-cy={COMMENT_EDITOR_SAVE_BUTTON_CYPRESS}
           color="primary"
           variant="contained"
-          onClick={() => onSendHandler(text)}
-          loading={askChatbotLoading || sendMessageLoading}
+          onClick={() => send(text)}
+          loading={isLoading}
           name="send"
         >
           {t('SEND_LABEL')}

--- a/src/modules/common/CommentEditor.tsx
+++ b/src/modules/common/CommentEditor.tsx
@@ -87,7 +87,7 @@ function CommentEditor({
           value={text}
           onChange={handleTextChange}
           role="textbox"
-          disabled={sendMessageLoading || askChatbotLoading}
+          disabled={isLoading}
           // use default font instead of textarea's monospace font
           style={{ fontFamily: 'unset' }}
         />

--- a/src/modules/common/Suggestions.tsx
+++ b/src/modules/common/Suggestions.tsx
@@ -1,28 +1,56 @@
+import { useTranslation } from 'react-i18next';
+
 import { Button, Stack, styled } from '@mui/material';
 
+import { AppActionsType } from '@/config/appActions';
 import { ChatbotPromptSettings } from '@/config/appSetting';
+import { mutations } from '@/config/queryClient';
+import { showErrorToast } from '@/utils/toast';
 
 import { useSendMessageAndAskChatbot } from './useSendMessageAndAskChatbot';
 
-const StyledButton = styled(Button)(({ theme }) => ({
+const StyledButton = styled(Button)({
   borderRadius: 100,
   textTransform: 'unset',
-}));
+});
 
 export function Suggestions({
   suggestions,
   chatbotPrompt,
-}: {
+}: Readonly<{
   chatbotPrompt: ChatbotPromptSettings;
   suggestions: string[];
-}) {
+}>) {
+  const { t } = useTranslation();
+  const { mutateAsync: postAction } = mutations.usePostAppAction();
   const { send } = useSendMessageAndAskChatbot({ chatbotPrompt });
+
+  const onClick = async (suggestion: string) => {
+    try {
+      await send(suggestion);
+      await postAction({
+        type: AppActionsType.UseStarter,
+        data: { value: suggestion },
+      });
+    } catch (e: unknown) {
+      if (e instanceof Error) {
+        showErrorToast(e.message);
+      }
+      console.error(e);
+    }
+  };
 
   return (
     <Stack direction="row" gap={2} justifyContent="right">
       {suggestions.map((s) => (
         <span key={s}>
-          <StyledButton onClick={() => send(s)} variant="contained">
+          <StyledButton
+            aria-label={t('STARTER_SUGGESTION_PLAYER_BUTTON_ARIA_LABEL', {
+              suggestion: s,
+            })}
+            onClick={() => onClick(s)}
+            variant="contained"
+          >
             {s}
           </StyledButton>
         </span>

--- a/src/modules/common/Suggestions.tsx
+++ b/src/modules/common/Suggestions.tsx
@@ -1,0 +1,32 @@
+import { Button, Stack, styled } from '@mui/material';
+
+import { ChatbotPromptSettings } from '@/config/appSetting';
+
+import { useSendMessageAndAskChatbot } from './useSendMessageAndAskChatbot';
+
+const StyledButton = styled(Button)(({ theme }) => ({
+  borderRadius: 100,
+  textTransform: 'unset',
+}));
+
+export function Suggestions({
+  suggestions,
+  chatbotPrompt,
+}: {
+  chatbotPrompt: ChatbotPromptSettings;
+  suggestions: string[];
+}) {
+  const { send } = useSendMessageAndAskChatbot({ chatbotPrompt });
+
+  return (
+    <Stack direction="row" gap={2} justifyContent="right">
+      {suggestions.map((s) => (
+        <span key={s}>
+          <StyledButton onClick={() => send(s)} variant="contained">
+            {s}
+          </StyledButton>
+        </span>
+      ))}
+    </Stack>
+  );
+}

--- a/src/modules/common/useConversation.tsx
+++ b/src/modules/common/useConversation.tsx
@@ -13,7 +13,10 @@ export type Comment = {
   username: string;
 };
 
-export const useConversation = (accountId?: string) => {
+export const useConversation = ({
+  accountId,
+  showSuggestions,
+}: Readonly<{ accountId?: string; showSuggestions?: boolean }>) => {
   const { data: appData, isLoading: isAppDataLoading } =
     hooks.useAppData<CommentData>();
   const { data: chatbotPromptSettings, isLoading: isChatbotSettingsLoading } =
@@ -61,5 +64,10 @@ export const useConversation = (accountId?: string) => {
     chatbotPrompt,
     chatbotAvatar: avatar,
     isLoading: isAppDataLoading || isChatbotSettingsLoading || isAvatarLoading,
+    // get suggestions if we want to show the suggestions and if there are no comments
+    suggestions:
+      showSuggestions && chatbotPrompt && 0 === comments.length
+        ? chatbotPrompt.starterSuggestions
+        : [],
   };
 };

--- a/src/modules/common/useSendMessageAndAskChatbot.ts
+++ b/src/modules/common/useSendMessageAndAskChatbot.ts
@@ -1,0 +1,46 @@
+import { useCallback } from 'react';
+
+import { ChatbotPromptSettings } from '@/config/appSetting';
+
+import { useAskChatbot } from './useAskChatbot';
+import { useSendMessage } from './useSendMessage';
+
+/**
+ * @returns `send` save a message as app data and save a chatbot reply as app data
+ * @returns `isLoading` whether a send is loading
+ */
+export const useSendMessageAndAskChatbot = ({
+  chatbotPrompt,
+  onSend,
+}: {
+  chatbotPrompt: ChatbotPromptSettings;
+  onSend?: () => void;
+}) => {
+  const { generateChatbotAnswer, isLoading: askChatbotLoading } =
+    useAskChatbot(chatbotPrompt);
+  const { sendMessage, isLoading: sendMessageLoading } =
+    useSendMessage(chatbotPrompt);
+
+  const send = useCallback(
+    async (newUserComment: string) => {
+      if (!chatbotPrompt) {
+        throw new Error(
+          "unexpected error, chatbot setting is not present, can't sent to API without it",
+        );
+      }
+
+      try {
+        const userMessage = await sendMessage(newUserComment);
+
+        await generateChatbotAnswer(userMessage.id, newUserComment);
+
+        onSend?.();
+      } catch (e) {
+        console.error(e);
+      }
+    },
+    [chatbotPrompt, generateChatbotAnswer, onSend, sendMessage],
+  );
+
+  return { send, isLoading: askChatbotLoading || sendMessageLoading };
+};

--- a/src/modules/main/ConversationsView.tsx
+++ b/src/modules/main/ConversationsView.tsx
@@ -138,7 +138,7 @@ function ConversationsView() {
         title={t('DISCUSSION_DIALOG_TITLE', { user: currentUser.name })}
         onClose={onCloseDialog}
       >
-        <ConversationForUser userId={currentUser.id} />
+        <ConversationForUser accountId={currentUser.id} />
         <IconButton
           data-cy={TABLE_VIEW_REVIEW_DIALOG_CLOSE_BUTTON_CYPRESS}
           onClick={onCloseDialog}

--- a/src/modules/main/PlayerView.tsx
+++ b/src/modules/main/PlayerView.tsx
@@ -10,8 +10,11 @@ import { useConversation } from '../common/useConversation';
 function PlayerView(): JSX.Element {
   const { t } = useTranslation();
   const { accountId } = useLocalContext();
-  const { chatbotPrompt, comments, isLoading, chatbotAvatar } =
-    useConversation(accountId);
+  const { chatbotPrompt, comments, isLoading, suggestions, chatbotAvatar } =
+    useConversation({
+      accountId,
+      showSuggestions: true,
+    });
 
   if (!accountId) {
     return <Typography>{t('SIGN_OUT_ALERT')}</Typography>;
@@ -24,6 +27,7 @@ function PlayerView(): JSX.Element {
       comments={comments}
       chatbotPrompt={chatbotPrompt}
       chatbotAvatar={chatbotAvatar}
+      suggestions={suggestions}
     />
   );
 }

--- a/src/modules/settings/ChatbotSettings.tsx
+++ b/src/modules/settings/ChatbotSettings.tsx
@@ -39,6 +39,7 @@ const useChatbotSetting = () => {
   const { avatar } = useChatbotAvatar();
 
   const initialPrompt = setting?.data?.initialPrompt ?? '';
+  const starterSuggestions = setting?.data.starterSuggestions ?? [];
 
   const saveSetting = useCallback(
     async (data: ChatbotPromptSettings): Promise<void> => {
@@ -63,14 +64,21 @@ const useChatbotSetting = () => {
     chatbotName,
     chatbotAvatar: avatar,
     saveSetting,
+    starterSuggestions,
   };
 };
 
 function ChatbotSettings() {
   const { t } = useTranslation();
 
-  const { saveSetting, chatbotCue, chatbotName, initialPrompt, chatbotAvatar } =
-    useChatbotSetting();
+  const {
+    saveSetting,
+    chatbotCue,
+    chatbotName,
+    initialPrompt,
+    chatbotAvatar,
+    starterSuggestions,
+  } = useChatbotSetting();
   const saveNewAvatar = useSaveAvatar();
 
   const [isEditing, setIsEditing] = useState(false);
@@ -128,6 +136,7 @@ function ChatbotSettings() {
             name: chatbotName,
             cue: chatbotCue,
             prompt: initialPrompt,
+            starterSuggestions,
           }}
           onSave={handleOnSave}
         />

--- a/src/modules/settings/ChatbotSettings.tsx
+++ b/src/modules/settings/ChatbotSettings.tsx
@@ -10,6 +10,7 @@ import {
   Grid2,
   Stack,
   Typography,
+  useTheme,
 } from '@mui/material';
 
 import { Edit, Undo2 } from 'lucide-react';
@@ -69,6 +70,7 @@ const useChatbotSetting = () => {
 };
 
 function ChatbotSettings() {
+  const theme = useTheme();
   const { t } = useTranslation();
 
   const {
@@ -193,6 +195,29 @@ function ChatbotSettings() {
                 ) : (
                   <Typography color="text.disabled" fontStyle="italic">
                     {t('CHATBOT_CUE_EMPTY_MESSAGE')}
+                  </Typography>
+                )}
+              </Grid2>
+
+              <Grid2 size={{ xs: 12, sm: 4 }}>
+                <FormLabel sx={{ fontWeight: 'bold' }}>
+                  {t('CHATBOT_STARTER_SUGGESTIONS_LABEL')}
+                </FormLabel>
+              </Grid2>
+              <Grid2 size={{ xs: 12, sm: 8 }}>
+                {starterSuggestions.length ? (
+                  <ul
+                    style={{ marginBlock: 0, paddingInline: theme.spacing(2) }}
+                  >
+                    {starterSuggestions.map((s) => (
+                      <Typography key={s} variant="body1" component="li">
+                        {s}
+                      </Typography>
+                    ))}
+                  </ul>
+                ) : (
+                  <Typography color="text.disabled" fontStyle="italic">
+                    {t('CHATBOT_STARTER_SUGGESTIONS_EMPTY_MESSAGE')}
                   </Typography>
                 )}
               </Grid2>

--- a/src/modules/settings/ChatbotSettings.tsx
+++ b/src/modules/settings/ChatbotSettings.tsx
@@ -6,7 +6,6 @@ import {
   Button,
   Card,
   CardContent,
-  CircularProgress,
   FormLabel,
   Grid2,
   Stack,
@@ -31,7 +30,7 @@ import { useSaveAvatar } from './useNewAvatar';
 const useChatbotSetting = () => {
   const { mutateAsync: postSetting } = mutations.usePostAppSetting();
   const { mutateAsync: patchSetting } = mutations.usePatchAppSetting();
-  const { data: chatbotPromptSettings, isFetching } =
+  const { data: chatbotPromptSettings } =
     hooks.useAppSettings<ChatbotPromptSettings>({
       name: SettingsKeys.ChatbotPrompt,
     });
@@ -67,7 +66,6 @@ const useChatbotSetting = () => {
     chatbotAvatar: avatar,
     saveSetting,
     starterSuggestions,
-    isFetching,
   };
 };
 
@@ -82,7 +80,6 @@ function ChatbotSettings() {
     initialPrompt,
     chatbotAvatar,
     starterSuggestions,
-    isFetching,
   } = useChatbotSetting();
   const saveNewAvatar = useSaveAvatar();
 
@@ -116,7 +113,6 @@ function ChatbotSettings() {
       >
         <Typography variant="h2" fontWeight="bold" fontSize="1.5rem">
           {t('CHATBOT_SETTING_TITLE')}
-          {isFetching && <CircularProgress size="small" />}
         </Typography>
         <Button
           endIcon={isEditing ? <Undo2 /> : <Edit />}

--- a/src/modules/settings/ChatbotSettings.tsx
+++ b/src/modules/settings/ChatbotSettings.tsx
@@ -6,6 +6,7 @@ import {
   Button,
   Card,
   CardContent,
+  CircularProgress,
   FormLabel,
   Grid2,
   Stack,
@@ -30,7 +31,7 @@ import { useSaveAvatar } from './useNewAvatar';
 const useChatbotSetting = () => {
   const { mutateAsync: postSetting } = mutations.usePostAppSetting();
   const { mutateAsync: patchSetting } = mutations.usePatchAppSetting();
-  const { data: chatbotPromptSettings } =
+  const { data: chatbotPromptSettings, isFetching } =
     hooks.useAppSettings<ChatbotPromptSettings>({
       name: SettingsKeys.ChatbotPrompt,
     });
@@ -66,6 +67,7 @@ const useChatbotSetting = () => {
     chatbotAvatar: avatar,
     saveSetting,
     starterSuggestions,
+    isFetching,
   };
 };
 
@@ -80,6 +82,7 @@ function ChatbotSettings() {
     initialPrompt,
     chatbotAvatar,
     starterSuggestions,
+    isFetching,
   } = useChatbotSetting();
   const saveNewAvatar = useSaveAvatar();
 
@@ -113,6 +116,7 @@ function ChatbotSettings() {
       >
         <Typography variant="h2" fontWeight="bold" fontSize="1.5rem">
           {t('CHATBOT_SETTING_TITLE')}
+          {isFetching && <CircularProgress size="small" />}
         </Typography>
         <Button
           endIcon={isEditing ? <Undo2 /> : <Edit />}

--- a/src/modules/settings/chatbot/ChatbotEditingView.tsx
+++ b/src/modules/settings/chatbot/ChatbotEditingView.tsx
@@ -9,12 +9,14 @@ import { TextArea } from '@/modules/common/TextArea';
 
 import { ChatbotAvatarEditor } from './ChatbotAvatarEditor';
 import { ChatbotSetting } from './ChatbotSetting';
+import StarterSuggestions, { InternalSuggestion } from './StarterSuggestions';
 
 type Props = {
   initialValue: {
     name: string;
     cue: string;
     prompt: string;
+    starterSuggestions: string[];
   };
   onSave: (data: ChatbotPromptSettings, avatar?: Blob) => Promise<void>;
 };
@@ -29,6 +31,11 @@ function ChatbotEditionView({
   const [name, setName] = useState(initialValue.name);
   const [newAvatar, setNewAvatar] = useState<Blob>();
   const [isSaving, setIsSaving] = useState(false);
+
+  // create id for suggestions, it is important for managing
+  const [starterSuggestions, setStarterSuggestions] = useState(
+    initialValue.starterSuggestions.map((s, idx) => ({ value: s, id: idx })),
+  );
 
   const [unsavedChanges, setUnsavedChanges] = useState(false);
 
@@ -52,6 +59,13 @@ function ChatbotEditionView({
     setUnsavedChanges(true);
   };
 
+  const handleChangeStarterConversations = (
+    value: InternalSuggestion[],
+  ): void => {
+    setStarterSuggestions(value);
+    setUnsavedChanges(true);
+  };
+
   const handleSave = async () => {
     if (prompt) {
       setIsSaving(true);
@@ -60,6 +74,10 @@ function ChatbotEditionView({
         initialPrompt: prompt,
         chatbotCue: cue,
         chatbotName: name,
+        // remove empty values and revert to array of string
+        starterSuggestions: starterSuggestions
+          .filter((suggestion) => suggestion.value)
+          .map(({ value }) => value),
       };
       await onSave(data, newAvatar);
 
@@ -105,6 +123,16 @@ function ChatbotEditionView({
           name={t('CHATBOT_CUE_LABEL')}
           value={cue}
           onChange={({ target: { value } }) => handleChangeChatbotCue(value)}
+        />
+      </ChatbotSetting>
+
+      <ChatbotSetting
+        title={t('CHATBOT_STARTER_SUGGESTION_LABEL')}
+        description={t('CHATBOT_STARTER_SUGGESTION_HELPER')}
+      >
+        <StarterSuggestions
+          starterSuggestions={starterSuggestions}
+          onChange={handleChangeStarterConversations}
         />
       </ChatbotSetting>
 

--- a/src/modules/settings/chatbot/StarterSuggestions.tsx
+++ b/src/modules/settings/chatbot/StarterSuggestions.tsx
@@ -1,3 +1,5 @@
+import { useTranslation } from 'react-i18next';
+
 import { Button, IconButton, Stack, TextField } from '@mui/material';
 
 import { PlusIcon, TrashIcon } from 'lucide-react';
@@ -11,10 +13,12 @@ function StarterSuggestions({
   starterSuggestions: InternalSuggestion[];
   onChange: (args: InternalSuggestion[]) => void;
 }>) {
+  const { t } = useTranslation();
+
   const add = () => {
     // increase id based on last one
     // this works as long as we don't reorder
-    const lastId = starterSuggestions.at(-1)?.id ?? 0;
+    const lastId = starterSuggestions.at(-1)?.id ?? -1;
     onChange([
       ...starterSuggestions,
       {
@@ -43,18 +47,28 @@ function StarterSuggestions({
           <TextField
             size="small"
             fullWidth
-            placeholder="Write a suggestion here"
+            placeholder={t('STARTER_SUGGESTION_PLACEHOLDER')}
             defaultValue={value}
             onChange={(e) => edit(e.target.value, id)}
+            name={t('STARTER_SUGGESTION_NAME', { nb: id })}
           />
-          <IconButton color="error" onClick={() => remove(id)}>
+          <IconButton
+            title={t('DELETE_STARTER_SUGGESTION_BUTTON_TITLE', { nb: id })}
+            color="error"
+            onClick={() => remove(id)}
+          >
             <TrashIcon />
           </IconButton>
         </Stack>
       ))}
       <span>
-        <Button startIcon={<PlusIcon />} color="primary" onClick={add}>
-          Add
+        <Button
+          startIcon={<PlusIcon />}
+          color="primary"
+          onClick={add}
+          title={t('ADD_STARTER_SUGGESTION_BUTTON_TITLE')}
+        >
+          {t('ADD_STARTER_SUGGESTION_BUTTON')}
         </Button>
       </span>
     </Stack>

--- a/src/modules/settings/chatbot/StarterSuggestions.tsx
+++ b/src/modules/settings/chatbot/StarterSuggestions.tsx
@@ -61,6 +61,7 @@ function StarterSuggestions({
           </IconButton>
         </Stack>
       ))}
+      {/* the span is used to prevent full width button */}
       <span>
         <Button
           startIcon={<PlusIcon />}

--- a/src/modules/settings/chatbot/StarterSuggestions.tsx
+++ b/src/modules/settings/chatbot/StarterSuggestions.tsx
@@ -1,0 +1,64 @@
+import { Button, IconButton, Stack, TextField } from '@mui/material';
+
+import { PlusIcon, TrashIcon } from 'lucide-react';
+
+export type InternalSuggestion = { value: string; id: number };
+
+function StarterSuggestions({
+  starterSuggestions = [],
+  onChange,
+}: Readonly<{
+  starterSuggestions: InternalSuggestion[];
+  onChange: (args: InternalSuggestion[]) => void;
+}>) {
+  const add = () => {
+    // increase id based on last one
+    // this works as long as we don't reorder
+    const lastId = starterSuggestions.at(-1)?.id ?? 0;
+    onChange([
+      ...starterSuggestions,
+      {
+        value: '',
+        id: lastId + 1,
+      },
+    ]);
+  };
+
+  const remove = (id: number) => {
+    onChange(starterSuggestions.filter(({ id: thisId }) => id !== thisId));
+  };
+
+  const edit = (newValue: string, editedId: number) => {
+    onChange(
+      starterSuggestions.map(({ value, id }) =>
+        id === editedId ? { value: newValue, id: editedId } : { value, id },
+      ),
+    );
+  };
+
+  return (
+    <Stack gap={1} alignItems="left">
+      {starterSuggestions.map(({ value, id }) => (
+        <Stack direction="row" gap={1} key={id}>
+          <TextField
+            size="small"
+            fullWidth
+            placeholder="Write a suggestion here"
+            defaultValue={value}
+            onChange={(e) => edit(e.target.value, id)}
+          />
+          <IconButton color="error" onClick={() => remove(id)}>
+            <TrashIcon />
+          </IconButton>
+        </Stack>
+      ))}
+      <span>
+        <Button startIcon={<PlusIcon />} color="primary" onClick={add}>
+          Add
+        </Button>
+      </span>
+    </Stack>
+  );
+}
+
+export default StarterSuggestions;


### PR DESCRIPTION
Add setting to setup starter messages a user can send to init the conversation (named `starter suggestion`).

TODO:
- [x] show starter in settings view -> waiting for #352 
- [x] complete tests


https://github.com/user-attachments/assets/abdaf2b5-486f-4906-a7e1-a01960a2476c

 

https://github.com/user-attachments/assets/72605a8b-e557-4e16-ac92-07644f5e607a


