### PR TITLE
feat: show error in edition view, use textfield multiline

### DIFF
--- a/cypress/e2e/builder/main.cy.ts
+++ b/cypress/e2e/builder/main.cy.ts
@@ -9,7 +9,7 @@ import {
 import { MOCK_APP_SETTING } from '../../fixtures/mockSettings';
 
 const EDIT_SETTINGS_BUTTON = '[type="button"]:contains("Edit")';
-const SAVE_SETTINGS_BUTTON = '[type="button"]:contains("Save")';
+const SAVE_SETTINGS_BUTTON = '[type="submit"]:contains("Save")';
 const PROMPT_TEXT_AREA = '[name="Chatbot Prompt"]';
 const CUE_TEXT_AREA = '[name="Conversation Starter"]';
 const CHATBOT_NAME_INPUT = '[name="Chatbot Name"]';
@@ -169,5 +169,40 @@ describe('Builder View', () => {
     for (const s of remainingSuggestions) {
       cy.get(`li:contains('${s}')`).should('be.visible');
     }
+  });
+
+  it('Cannot save empty chatbot name or empty prompt', () => {
+    cy.setUpApi(
+      {},
+      {
+        context: Context.Builder,
+        permission: PermissionLevel.Admin,
+      },
+    );
+    cy.visit('/');
+
+    cy.get(buildDataCy(TAB_SETTINGS_VIEW_CYPRESS)).click();
+
+    cy.get(EDIT_SETTINGS_BUTTON).click();
+
+    cy.get(SAVE_SETTINGS_BUTTON).should('be.disabled');
+
+    // change cue and cannot save despite changes
+    const cue = 'my new cue';
+    cy.get(CUE_TEXT_AREA).clear().type(cue);
+    cy.get(SAVE_SETTINGS_BUTTON).should('be.disabled');
+
+    // change prompt and can save
+    const prompt = 'my new prompt';
+    cy.get(PROMPT_TEXT_AREA).type(prompt);
+    cy.get(SAVE_SETTINGS_BUTTON).should('not.be.disabled');
+
+    // remove name and cannot save
+    cy.get(CHATBOT_NAME_INPUT).clear();
+    cy.get(SAVE_SETTINGS_BUTTON).should('be.disabled');
+
+    // add back a name and can save
+    cy.get(CHATBOT_NAME_INPUT).type('a name');
+    cy.get(SAVE_SETTINGS_BUTTON).should('not.be.disabled');
   });
 });

--- a/cypress/e2e/player/main.cy.ts
+++ b/cypress/e2e/player/main.cy.ts
@@ -22,6 +22,7 @@ const defaultAppData = [
   },
 ];
 
+const MESSAGE_INPUT = 'textarea[name="Message"]';
 const SEND_BUTTON = '[name="Send message"]';
 
 describe('Player View', () => {
@@ -47,7 +48,7 @@ describe('Player View', () => {
 
     // type and send message
     const message = 'My message';
-    cy.get('[role="textbox"]').type(message);
+    cy.get(MESSAGE_INPUT).type(message);
     cy.get(SEND_BUTTON).click();
 
     // expect user message
@@ -84,7 +85,7 @@ describe('Player View', () => {
 
     // type and send message
     const message = 'My message';
-    cy.get('[role="textbox"]').type(message);
+    cy.get(MESSAGE_INPUT).type(message);
     cy.get(SEND_BUTTON).click();
 
     // expect user message
@@ -189,7 +190,7 @@ describe('Player View', () => {
 
     // type and send message with enter key
     const message = 'My message';
-    cy.get('[role="textbox"]').type(message).type('{enter}');
+    cy.get(MESSAGE_INPUT).type(message).type('{enter}');
 
     // expect user message
     cy.get(buildDataCy(buildCommentContainerDataCy('2'))).should(
@@ -199,7 +200,7 @@ describe('Player View', () => {
 
     // type and send message with enter key
     const message1 = 'My second message';
-    cy.get('[role="textbox"]').type(message1, { delay: 20 }).type('{enter}');
+    cy.get(MESSAGE_INPUT).type(message1, { delay: 20 }).type('{enter}');
 
     // expect message to not be sent
     cy.get('[role="log"]').should('not.contain', message1);
@@ -207,7 +208,7 @@ describe('Player View', () => {
     // explicitely wait for chatbot to answer before sending another message
     cy.wait(1000);
 
-    cy.get('[role="textbox"]').type('{enter}');
+    cy.get(MESSAGE_INPUT).type('{enter}');
 
     // expect user message
     cy.get(buildDataCy(buildCommentContainerDataCy('4'))).should(

--- a/src/config/selectors.ts
+++ b/src/config/selectors.ts
@@ -27,7 +27,6 @@ export const CUSTOM_DIALOG_TITLE_CYPRESS = 'custom_dialog_title';
 export const CUSTOM_DIALOG_ACTIONS_CYPRESS = 'custom_dialog_actions';
 export const CUSTOM_DIALOG_CONTENT_CY = 'custom_dialog_content';
 
-export const NUMBER_OF_COMMENTS_CYPRESS = 'number_of_comments';
 export const TABLE_NO_COMMENTS_CYPRESS = 'table_no_comments';
 export const SETTINGS_SPEED_FAB_CYPRESS = 'settings_speed_fab';
 export const DISPLAY_SETTINGS_FAB_CYPRESS = 'display_settings_fab';
@@ -48,22 +47,6 @@ export const SHOW_VERSION_NAVIGATION_SWITCH_CYPRESS =
 export const tableRowUserCypress = (id: string): string =>
   `${TABLE_ROW_USERS_CYPRESS}-${id}`;
 
-export const COMMENT_EDITOR_CYPRESS = 'comment_editor';
-export const COMMENT_EDITOR_CANCEL_BUTTON_CYPRESS =
-  'comment_editor_cancel_button';
-export const COMMENT_EDITOR_SAVE_BUTTON_CYPRESS = 'comment_editor_save_button';
-export const COMMENT_EDITOR_BOLD_BUTTON_CYPRESS = 'comment_editor_bold_button';
-export const COMMENT_EDITOR_ITALIC_BUTTON_CYPRESS =
-  'comment_editor_italic_button';
-export const COMMENT_EDITOR_CODE_BUTTON_CYPRESS = 'comment_editor_code_button';
-export const COMMENT_EDITOR_LINK_BUTTON_CYPRESS = 'comment_editor_link_button';
-export const COMMENT_EDITOR_QUOTE_BUTTON_CYPRESS =
-  'comment_editor_quote_button';
-export const COMMENT_EDITOR_LINE_INFO_TEXT_CYPRESS =
-  'comment_editor_line_info_text';
-export const COMMENT_EDITOR_TEXTAREA_CYPRESS = 'comment_editor_textarea';
-export const COMMENT_EDITOR_TEXTAREA_HELPER_TEXT_CY =
-  'comment_editor_textarea_helper_text';
 export const COMMENT_CONTAINER_CYPRESS = 'comment_container';
 export const CHATBOT_PROMPT_CONTAINER_CY = 'chatbot_prompt_container';
 export const COMMENT_RESPONSE_BOX_CY = 'comment-response-box';

--- a/src/langs/en.json
+++ b/src/langs/en.json
@@ -75,6 +75,8 @@
     "DELETE_STARTER_SUGGESTION_BUTTON_TITLE": "Delete suggestion number {{nb}}",
     "STARTER_SUGGESTION_PLACEHOLDER": "Write a suggestion here",
     "STARTER_SUGGESTION_PLAYER_BUTTON_ARIA_LABEL": "Ask {{suggestion}}",
-    "SEND_MESSAGE_BUTTON": "Send message"
+    "SEND_MESSAGE_BUTTON": "Send message",
+    "EDIT_CHATBOT": "Edit chatbot",
+    "MESSAGE_INPUT_LABEL": "Message"
   }
 }

--- a/src/langs/fr.json
+++ b/src/langs/fr.json
@@ -62,6 +62,8 @@
     "STARTER_SUGGESTION_NAME": "Suggestion de conversation numéro {{nb}}",
     "DELETE_STARTER_SUGGESTION_BUTTON_TITLE": "Supprimer la suggestion de conversation numéro {{nb}}",
     "STARTER_SUGGESTION_PLACEHOLDER": "Écrire une suggestion ici",
-    "STARTER_SUGGESTION_PLAYER_BUTTON_ARIA_LABEL": "Demander {{suggestion}}"
+    "STARTER_SUGGESTION_PLAYER_BUTTON_ARIA_LABEL": "Demander {{suggestion}}",
+    "EDIT_CHATBOT": "Modifier le chatbot",
+    "MESSAGE_INPUT_LABEL": "Message"
   }
 }

--- a/src/modules/common/CommentEditor.tsx
+++ b/src/modules/common/CommentEditor.tsx
@@ -6,20 +6,13 @@ import {
   FormHelperText,
   IconButton,
   Stack,
-  TextareaAutosize,
+  TextField,
   styled,
 } from '@mui/material';
 
 import { SendHorizonal } from 'lucide-react';
 
 import { DEFAULT_GENERAL_SETTINGS } from '@/config/appSetting';
-import {
-  COMMENT_EDITOR_CYPRESS,
-  COMMENT_EDITOR_SAVE_BUTTON_CYPRESS,
-  COMMENT_EDITOR_TEXTAREA_CYPRESS,
-  COMMENT_EDITOR_TEXTAREA_HELPER_TEXT_CY,
-} from '@/config/selectors';
-import { SMALL_BORDER_RADIUS } from '@/constants';
 
 const SendButton = styled(IconButton)(({ theme }) => ({
   background: theme.palette.primary.main,
@@ -27,25 +20,6 @@ const SendButton = styled(IconButton)(({ theme }) => ({
 
   '&:hover': {
     background: '#96CCFF',
-  },
-}));
-
-const TextArea = styled(TextareaAutosize)(({ theme }) => ({
-  borderRadius: SMALL_BORDER_RADIUS,
-  padding: theme.spacing(1),
-  fontSize: '1rem',
-  boxSizing: 'border-box',
-  resize: 'vertical',
-  border: 0,
-  outline: 'solid rgba(80, 80, 210, 0.5) 1px',
-  width: '100%',
-  minWidth: '0',
-  transition: 'outline 250ms ease-in-out',
-  '&:focus': {
-    outline: 'solid var(--graasp-primary) 2px !important',
-  },
-  '&:hover': {
-    outline: 'solid var(--graasp-primary) 1px ',
   },
 }));
 
@@ -77,7 +51,7 @@ function CommentEditor({
     }
   };
 
-  const onKeyDown: KeyboardEventHandler<HTMLTextAreaElement> = (event) => {
+  const onKeyDown: KeyboardEventHandler<HTMLDivElement> = (event) => {
     const { key, shiftKey } = event;
     // send message on enter if is not loading
     if ('Enter' === key && !shiftKey) {
@@ -98,26 +72,23 @@ function CommentEditor({
   };
 
   return (
-    <Box sx={{ p: 1 }} data-cy={COMMENT_EDITOR_CYPRESS}>
+    <Box sx={{ p: 1 }}>
       <Stack direction="row" spacing={1} alignItems="center">
-        <TextArea
-          data-cy={COMMENT_EDITOR_TEXTAREA_CYPRESS}
+        <TextField
+          name={t('MESSAGE_INPUT_LABEL')}
           placeholder={t('COMMENT_PLACEHOLDER')}
-          minRows={1}
-          maxRows={10}
+          multiline
+          fullWidth
           value={text}
           onChange={handleTextChange}
-          role="textbox"
-          // use default font instead of textarea's monospace font
-          style={{ fontFamily: 'unset' }}
           onKeyDown={onKeyDown}
+          minRows={1}
+          maxRows={10}
+          required
         />
-        <FormHelperText data-cy={COMMENT_EDITOR_TEXTAREA_HELPER_TEXT_CY} error>
-          {textTooLong || ' '}
-        </FormHelperText>
+        <FormHelperText error>{textTooLong || ' '}</FormHelperText>
         <SendButton
           onClick={onSend}
-          data-cy={COMMENT_EDITOR_SAVE_BUTTON_CYPRESS}
           name={t('SEND_MESSAGE_BUTTON')}
           disabled={isLoading}
         >

--- a/src/modules/settings/chatbot/ChatbotEditingView.tsx
+++ b/src/modules/settings/chatbot/ChatbotEditingView.tsx
@@ -7,7 +7,6 @@ import { Box, Button, Stack, TextField, Typography } from '@mui/material';
 import { Undo2Icon } from 'lucide-react';
 
 import { type ChatbotPromptSettings } from '@/config/appSetting';
-import { TextArea } from '@/modules/common/TextArea';
 
 import { ChatbotAvatarEditor } from './ChatbotAvatarEditor';
 import { ChatbotSetting } from './ChatbotSetting';
@@ -42,6 +41,10 @@ function ChatbotEditionView({
   );
 
   const [unsavedChanges, setUnsavedChanges] = useState(false);
+
+  // cannot save if there is no change, is saving or if prompt or name are empty
+  const isSaveButtonDisabled =
+    !unsavedChanges || isSaving || 0 === prompt.length || 0 === name.length;
 
   const onChangePrompt = (newValue: string) => {
     setPrompt(newValue);
@@ -97,7 +100,7 @@ function ChatbotEditionView({
         alignItems="flex-end"
       >
         <Typography variant="h5" component="h1" fontWeight="bold">
-          Edit chatbot
+          {t('EDIT_CHATBOT')}
         </Typography>
         <Button endIcon={<Undo2Icon />} variant="outlined" onClick={onCancel}>
           {t('CANCEL_LABEL')}
@@ -116,18 +119,24 @@ function ChatbotEditionView({
           fullWidth
           value={name}
           onChange={({ target: { value } }) => handleChangeChatbotName(value)}
+          required
+          error={0 === name.length}
         />
       </Stack>
 
       <ChatbotSetting
         title={t('CHATBOT_PROMPT_LABEL')}
         description={t('CHATBOT_PROMPT_HELPER')}
+        required
       >
-        <TextArea
+        <TextField
           name={t('CHATBOT_PROMPT_LABEL')}
           value={prompt}
           onChange={({ target: { value } }) => onChangePrompt(value)}
           required
+          fullWidth
+          multiline
+          error={initialValue.prompt !== prompt && 0 === prompt.length}
         />
       </ChatbotSetting>
 
@@ -135,9 +144,11 @@ function ChatbotEditionView({
         title={t('CHATBOT_CUE_LABEL')}
         description={t('CHATBOT_CUE_HELPER')}
       >
-        <TextArea
+        <TextField
           name={t('CHATBOT_CUE_LABEL')}
           value={cue}
+          fullWidth
+          multiline
           onChange={({ target: { value } }) => handleChangeChatbotCue(value)}
         />
       </ChatbotSetting>
@@ -154,8 +165,9 @@ function ChatbotEditionView({
 
       <Box alignSelf="flex-end">
         <Button
+          type="submit"
           onClick={handleSave}
-          disabled={!unsavedChanges || isSaving}
+          disabled={isSaveButtonDisabled}
           variant="outlined"
           loading={isSaving}
         >

--- a/src/modules/settings/chatbot/ChatbotSetting.tsx
+++ b/src/modules/settings/chatbot/ChatbotSetting.tsx
@@ -2,18 +2,30 @@ import { ReactNode } from 'react';
 
 import { FormLabel, Grid2, Stack, Typography } from '@mui/material';
 
-type Props = { title: string; description: string; children: ReactNode };
+type Props = {
+  title: string;
+  description: string;
+  children: ReactNode;
+  required?: boolean;
+};
 
 export function ChatbotSetting({
   title,
   description,
   children,
+  required,
 }: Readonly<Props>): JSX.Element {
   return (
     <Grid2 container spacing={2}>
       <Grid2 size={5}>
         <Stack>
-          <FormLabel sx={{ fontSize: '1.2rem' }}>{title}</FormLabel>
+          <FormLabel
+            sx={{ fontSize: '1.2rem' }}
+            aria-label={title}
+            required={required}
+          >
+            {title}
+          </FormLabel>
           <Typography variant="caption" color="text.secondary">
             {description}
           </Typography>


### PR DESCRIPTION
- Show error in edition: cannot save if name or prompt are empty. It would be best to use `react-hooks`, especially for error message, but that would be for later.
- Prevent saving empty name or empty prompt
- Use `<TextField multiline>` instead `TextArea`

based on https://github.com/graasp/graasp-app-chatbot/pull/365

close #364 