### PR TITLE
fix: force minimum height for admin view

### DIFF
--- a/src/modules/main/AdminView.tsx
+++ b/src/modules/main/AdminView.tsx
@@ -45,7 +45,7 @@ function AdminView(): JSX.Element {
     });
 
   return (
-    <Box data-cy={BUILDER_VIEW_CY}>
+    <Box data-cy={BUILDER_VIEW_CY} minHeight={500}>
       <TabContext value={activeTab}>
         <TabList
           textColor="secondary"


### PR DESCRIPTION
@spaenleh let me know if there's another way, this one is quite hardcoded.

close #372 