### PR TITLE
feat: manage messages in conversations

### DIFF
--- a/cypress/e2e/player/main.cy.ts
+++ b/cypress/e2e/player/main.cy.ts
@@ -1,5 +1,6 @@
 import { AppDataVisibility, Context, PermissionLevel } from '@graasp/sdk';
 
+import type { CommentAppData } from '../../../src/config/appData';
 import {
   buildCommentContainerDataCy,
   buildDataCy,
@@ -25,6 +26,17 @@ const defaultAppData = [
 const MESSAGE_INPUT = 'textarea[name="Message"]';
 const SEND_BUTTON = '[name="Send message"]';
 
+const goToConversation = (appData: CommentAppData) => {
+  const txt = appData.data.content;
+  cy.contains('tr', txt.slice(0, 10))
+    .find('button[title="Open conversation"]')
+    .click();
+};
+
+const createConversation = () => {
+  cy.get('button:contains("New conversation")').click();
+};
+
 describe('Player View', () => {
   it('Show messages and write a new one', () => {
     cy.setUpApi(
@@ -38,6 +50,9 @@ describe('Player View', () => {
       },
     );
     cy.visit('/');
+
+    // go to conversation
+    goToConversation(defaultAppData[0]);
 
     // expect previously saved app data
     const [previousAppData] = defaultAppData;
@@ -76,6 +91,7 @@ describe('Player View', () => {
       },
     );
     cy.visit('/');
+    createConversation();
 
     // expect cue
     cy.get(buildDataCy(buildCommentContainerDataCy('cue'))).should(
@@ -102,32 +118,33 @@ describe('Player View', () => {
   });
 
   it('Show dates', () => {
+    const appData = [
+      {
+        account: CURRENT_MEMBER,
+        createdAt: '2025-11-18T16:35:22.010Z',
+        creator: CURRENT_MEMBER,
+        data: { content: 'A previously saved message' },
+        id: '0',
+        item: MOCK_SERVER_ITEM,
+        type: 'comment',
+        updatedAt: '2025-11-18T16:35:22.010Z',
+        visibility: AppDataVisibility.Member,
+      },
+      {
+        account: CURRENT_MEMBER,
+        createdAt: '2024-11-18T16:35:22.010Z',
+        creator: CURRENT_MEMBER,
+        data: { content: 'A previously saved message' },
+        id: '1',
+        item: MOCK_SERVER_ITEM,
+        type: 'comment',
+        updatedAt: '2025-11-18T16:35:22.010Z',
+        visibility: AppDataVisibility.Member,
+      },
+    ];
     cy.setUpApi(
       {
-        appData: [
-          {
-            account: CURRENT_MEMBER,
-            createdAt: '2025-11-18T16:35:22.010Z',
-            creator: CURRENT_MEMBER,
-            data: { content: 'A previously saved message' },
-            id: '0',
-            item: MOCK_SERVER_ITEM,
-            type: 'comment',
-            updatedAt: '2025-11-18T16:35:22.010Z',
-            visibility: AppDataVisibility.Member,
-          },
-          {
-            account: CURRENT_MEMBER,
-            createdAt: '2024-11-18T16:35:22.010Z',
-            creator: CURRENT_MEMBER,
-            data: { content: 'A previously saved message' },
-            id: '1',
-            item: MOCK_SERVER_ITEM,
-            type: 'comment',
-            updatedAt: '2025-11-18T16:35:22.010Z',
-            visibility: AppDataVisibility.Member,
-          },
-        ],
+        appData,
         appSettings: [MOCK_APP_SETTING],
       },
       {
@@ -136,6 +153,8 @@ describe('Player View', () => {
       },
     );
     cy.visit('/');
+    // go to conversation
+    goToConversation(appData[0]);
 
     // expect dates
     cy.get('#root').should('contain', 'November 18, 2024');
@@ -154,6 +173,7 @@ describe('Player View', () => {
       },
     );
     cy.visit('/');
+    createConversation();
 
     const [suggestion] = MOCK_APP_SETTING.data.starterSuggestions;
 
@@ -187,6 +207,7 @@ describe('Player View', () => {
       },
     );
     cy.visit('/');
+    createConversation();
 
     // type and send message with enter key
     const message = 'My message';
@@ -214,6 +235,111 @@ describe('Player View', () => {
     cy.get(buildDataCy(buildCommentContainerDataCy('4'))).should(
       'contain',
       message1,
+    );
+  });
+
+  it('Show all conversations', () => {
+    const appData = [
+      // first conversation
+      {
+        account: CURRENT_MEMBER,
+        createdAt: '2026-11-18T16:35:22.010Z',
+        creator: CURRENT_MEMBER,
+        data: {
+          content: 'My conversation',
+          conversationId: 'conversation-id-2',
+        },
+        id: '12',
+        item: MOCK_SERVER_ITEM,
+        type: 'comment',
+        updatedAt: '2026-11-18T16:35:22.010Z',
+        visibility: AppDataVisibility.Member,
+      },
+      // second, legacy conversation
+      {
+        account: CURRENT_MEMBER,
+        createdAt: '2025-10-18T16:35:22.010Z',
+        creator: CURRENT_MEMBER,
+        data: { content: 'A previously saved message' },
+        id: '0',
+        item: MOCK_SERVER_ITEM,
+        type: 'comment',
+        updatedAt: '2025-11-18T16:35:22.010Z',
+        visibility: AppDataVisibility.Member,
+      },
+      {
+        account: CURRENT_MEMBER,
+        createdAt: '2024-01-18T16:35:22.010Z',
+        creator: CURRENT_MEMBER,
+        data: { content: 'Another saved message' },
+        id: '14',
+        item: MOCK_SERVER_ITEM,
+        type: 'comment',
+        updatedAt: '2025-11-18T17:35:22.010Z',
+        visibility: AppDataVisibility.Member,
+      },
+      // third conversation
+      {
+        account: CURRENT_MEMBER,
+        createdAt: '2023-11-18T16:35:22.010Z',
+        creator: CURRENT_MEMBER,
+        data: {
+          content: 'A question I asked',
+          conversationId: 'conversation-id-1',
+        },
+        id: '13',
+        item: MOCK_SERVER_ITEM,
+        type: 'comment',
+        updatedAt: '2023-11-18T16:35:22.010Z',
+        visibility: AppDataVisibility.Member,
+      },
+    ];
+    cy.setUpApi(
+      {
+        appData,
+        appSettings: [MOCK_APP_SETTING],
+      },
+      {
+        context: Context.Player,
+        permission: PermissionLevel.Write,
+      },
+    );
+    cy.visit('/');
+
+    // should show 3 conversations ordered by creation date desc
+    cy.get('tr').then((rows) => {
+      expect(rows).to.have.length(3);
+
+      expect(rows[0]).to.contain(appData[0].data.content);
+      // content is cut because it is too long
+      expect(rows[1]).to.contain(appData[1].data.content.slice(0, 10));
+      expect(rows[2]).to.contain(appData[3].data.content);
+    });
+
+    // go to first conversation and show one message
+    goToConversation(appData[0]);
+    // expect one user message only
+    cy.get(buildDataCy(buildCommentContainerDataCy(appData[0].id))).should(
+      'be.visible',
+    );
+    cy.get(buildDataCy(buildCommentContainerDataCy(appData[1].id))).should(
+      'not.exist',
+    );
+
+    // go back to conversations
+    cy.get('button:contains("Go back to conversations")').click();
+
+    // go to second legacy conversation
+    goToConversation(appData[1]);
+    // expect one user message only
+    cy.get(buildDataCy(buildCommentContainerDataCy(appData[1].id))).should(
+      'be.visible',
+    );
+    cy.get(buildDataCy(buildCommentContainerDataCy(appData[2].id))).should(
+      'be.visible',
+    );
+    cy.get(buildDataCy(buildCommentContainerDataCy(appData[3].id))).should(
+      'not.exist',
     );
   });
 });

--- a/cypress/e2e/player/main.cy.ts
+++ b/cypress/e2e/player/main.cy.ts
@@ -238,7 +238,7 @@ describe('Player View', () => {
     );
   });
 
-  it('Show all conversations', () => {
+  it.only('Show all conversations', () => {
     const appData = [
       // first conversation
       {
@@ -312,7 +312,7 @@ describe('Player View', () => {
 
       expect(rows[0]).to.contain(appData[0].data.content);
       // content is cut because it is too long
-      expect(rows[1]).to.contain(appData[1].data.content.slice(0, 10));
+      expect(rows[1]).to.contain(appData[2].data.content.slice(0, 10));
       expect(rows[2]).to.contain(appData[3].data.content);
     });
 
@@ -330,7 +330,7 @@ describe('Player View', () => {
     cy.get('button:contains("Go back to conversations")').click();
 
     // go to second legacy conversation
-    goToConversation(appData[1]);
+    goToConversation(appData[2]);
     // expect one user message only
     cy.get(buildDataCy(buildCommentContainerDataCy(appData[1].id))).should(
       'be.visible',

--- a/src/config/appData.ts
+++ b/src/config/appData.ts
@@ -16,5 +16,10 @@ export type CommentData = {
   content: string;
   parent: string | null;
   chatbotPromptSettingId?: string;
+  /**
+   * Id of the conversation in which the comment belongs to
+   * Legacy data have an undefined value
+   */
+  conversationId?: string;
 };
 export type CommentAppData = AppData<CommentData>;

--- a/src/config/appData.ts
+++ b/src/config/appData.ts
@@ -14,7 +14,7 @@ export type VisibilityVariants = 'member' | 'item';
 
 export type CommentData = {
   content: string;
-  parent: string | null;
+  parent?: string | null;
   chatbotPromptSettingId?: string;
   /**
    * Id of the conversation in which the comment belongs to

--- a/src/langs/en.json
+++ b/src/langs/en.json
@@ -77,6 +77,11 @@
     "STARTER_SUGGESTION_PLAYER_BUTTON_ARIA_LABEL": "Ask {{suggestion}}",
     "SEND_MESSAGE_BUTTON": "Send message",
     "EDIT_CHATBOT": "Edit chatbot",
-    "MESSAGE_INPUT_LABEL": "Message"
+    "MESSAGE_INPUT_LABEL": "Message",
+    "List of Conversations": "List of Conversations",
+    "Conversation Name": "Conversation Name",
+    "Last Message Date": "Last Message Date",
+    "Actions": "Actions",
+    "Open conversation": "Open conversation"
   }
 }

--- a/src/langs/fr.json
+++ b/src/langs/fr.json
@@ -64,6 +64,11 @@
     "STARTER_SUGGESTION_PLACEHOLDER": "Écrire une suggestion ici",
     "STARTER_SUGGESTION_PLAYER_BUTTON_ARIA_LABEL": "Demander {{suggestion}}",
     "EDIT_CHATBOT": "Modifier le chatbot",
-    "MESSAGE_INPUT_LABEL": "Message"
+    "MESSAGE_INPUT_LABEL": "Message",
+    "List of Conversations": "Liste des discussions",
+    "Conversation Name": "Nom de la discussion",
+    "Last Message Date": "Date du dernier message",
+    "Actions": "Actions",
+    "Open conversation": "Ouvrir la discussion"
   }
 }

--- a/src/modules/analytics/FrequentWords.tsx
+++ b/src/modules/analytics/FrequentWords.tsx
@@ -46,7 +46,14 @@ function FrequentWords({
 
   const [selectedCustomWords, setSelectedCustomWords] = useState<string[]>([]);
   const [customWord, setCustomWord] = useState('');
-  const [chatMemberID, setChatMemberID] = useState('');
+  const [selectedConversation, setSelectedConversation] = useState<null | {
+    accountId: string;
+    conversationId?: string;
+  }>(null);
+
+  const closeConversation = () => {
+    setSelectedConversation(null);
+  };
 
   const isAllSelected = mostFrequentWords.every(
     (ele) => -1 < selectedFrequentWords.indexOf(ele),
@@ -136,7 +143,12 @@ function FrequentWords({
             sentence={ele.data.content}
             memberName={ele.account.name}
             words={[...selectedFrequentWords, ...selectedCustomWords]}
-            onClick={() => setChatMemberID(ele.account.id)}
+            onClick={() =>
+              setSelectedConversation({
+                accountId: ele.account.id,
+                conversationId: ele.data.conversationId,
+              })
+            }
             buttonId={buildCheckWholeMemberChatButtonId(ele.account.id)}
           />
         ))}
@@ -148,19 +160,17 @@ function FrequentWords({
           )
         }
       </Stack>
-      {chatMemberID && (
-        <Dialog
-          open
-          onClose={() => {
-            setChatMemberID('');
-          }}
-        >
+      {selectedConversation && (
+        <Dialog open onClose={closeConversation}>
           <DialogTitle>{t('ANALYTICS_CONVERSATION_MEMBER')}</DialogTitle>
           <DialogContent>
-            <ConversationForUser accountId={chatMemberID} />
+            <ConversationForUser
+              accountId={selectedConversation.accountId}
+              conversationId={selectedConversation.conversationId}
+            />
           </DialogContent>
           <DialogActions>
-            <Button>{t('CLOSE')}</Button>
+            <Button onClick={closeConversation}>{t('CLOSE')}</Button>
           </DialogActions>
         </Dialog>
       )}

--- a/src/modules/comment/ChatbotContainer.tsx
+++ b/src/modules/comment/ChatbotContainer.tsx
@@ -1,0 +1,28 @@
+import { ReactNode } from 'react';
+
+import { Stack, styled } from '@mui/material';
+
+import { BIG_BORDER_RADIUS } from '@/constants';
+
+const StyledContainer = styled('div')(({ theme }) => ({
+  backgroundColor: 'white',
+  border: 'solid silver 1px',
+  padding: theme.spacing(3, 0),
+  borderRadius: BIG_BORDER_RADIUS,
+}));
+
+export const ChatbotContainer = ({ children }: { children: ReactNode }) => {
+  return (
+    <Stack
+      sx={{
+        px: { xs: 2, sm: 10 },
+        maxWidth: '100ch',
+        m: 'auto',
+        height: '100%',
+      }}
+      gap={2}
+    >
+      <StyledContainer>{children}</StyledContainer>
+    </Stack>
+  );
+};

--- a/src/modules/comment/CommentContainer.tsx
+++ b/src/modules/comment/CommentContainer.tsx
@@ -1,22 +1,15 @@
-import { Divider, Stack, SxProps, Theme, styled } from '@mui/material';
+import { Divider, Stack, SxProps, Theme } from '@mui/material';
 
 import { ChatbotPromptSettings } from '@/config/appSetting';
 
-import { BIG_BORDER_RADIUS } from '../../constants';
 import { ChatbotTyping } from '../common/ChatbotTyping';
 import CommentEditor from '../common/CommentEditor';
 import CommentThread from '../common/CommentThread';
 import { Suggestions } from '../common/Suggestions';
 import { Comment } from '../common/useConversation';
 import { useSendMessageAndAskChatbot } from '../common/useSendMessageAndAskChatbot';
+import { ChatbotContainer } from './ChatbotContainer';
 import ChatbotHeader from './ChatbotHeader';
-
-const Container = styled('div')(({ theme }) => ({
-  backgroundColor: 'white',
-  border: 'solid silver 1px',
-  padding: theme.spacing(3, 0),
-  borderRadius: BIG_BORDER_RADIUS,
-}));
 
 export type CommentContainerProps = Readonly<{
   chatbotAvatar?: Blob;
@@ -26,6 +19,7 @@ export type CommentContainerProps = Readonly<{
   mode?: 'read' | 'write';
   suggestions?: string[];
   threadSx?: SxProps<Theme>;
+  conversationId?: string;
 }>;
 
 export function CommentContainer({
@@ -36,14 +30,16 @@ export function CommentContainer({
   chatbotAvatar,
   mode = 'read',
   suggestions,
+  conversationId,
 }: CommentContainerProps) {
   const { send, isLoading: isSendingMessageAndAsking } =
     useSendMessageAndAskChatbot({
       chatbotPrompt,
+      conversationId,
     });
 
   return (
-    <Container>
+    <ChatbotContainer>
       <Stack gap={3} px={2}>
         <Stack role="log" gap={3}>
           <ChatbotHeader avatar={chatbotAvatar} name={chatbotName} />
@@ -64,6 +60,6 @@ export function CommentContainer({
           )}
         </Stack>
       </Stack>
-    </Container>
+    </ChatbotContainer>
   );
 }

--- a/src/modules/comment/Conversation.tsx
+++ b/src/modules/comment/Conversation.tsx
@@ -1,6 +1,6 @@
 import { useTranslation } from 'react-i18next';
 
-import { Alert, Box, CircularProgress } from '@mui/material';
+import { Alert, CircularProgress } from '@mui/material';
 
 import { ChatbotPromptSettings } from '@/config/appSetting';
 
@@ -15,6 +15,7 @@ function Conversation({
   isLoading,
   mode = 'read',
   suggestions,
+  conversationId,
 }: Readonly<{
   chatbotAvatar?: Blob;
   chatbotPrompt?: ChatbotPromptSettings;
@@ -23,6 +24,7 @@ function Conversation({
   mode?: CommentContainerProps['mode'];
   suggestions?: string[];
   threadSx?: CommentContainerProps['threadSx'];
+  conversationId?: string;
 }>) {
   const { t } = useTranslation();
 
@@ -30,24 +32,16 @@ function Conversation({
     const { chatbotName } = chatbotPrompt;
 
     return (
-      <Box
-        sx={{
-          px: { xs: 2, sm: 10 },
-          maxWidth: '100ch',
-          m: 'auto',
-          height: '100%',
-        }}
-      >
-        <CommentContainer
-          chatbotAvatar={chatbotAvatar}
-          chatbotName={chatbotName}
-          threadSx={threadSx}
-          comments={comments}
-          chatbotPrompt={chatbotPrompt}
-          mode={mode}
-          suggestions={suggestions}
-        />
-      </Box>
+      <CommentContainer
+        chatbotAvatar={chatbotAvatar}
+        chatbotName={chatbotName}
+        threadSx={threadSx}
+        comments={comments}
+        chatbotPrompt={chatbotPrompt}
+        mode={mode}
+        suggestions={suggestions}
+        conversationId={conversationId}
+      />
     );
   }
 

--- a/src/modules/comment/ConversationForUser.tsx
+++ b/src/modules/comment/ConversationForUser.tsx
@@ -3,9 +3,10 @@ import Conversation from './Conversation';
 
 export const ConversationForUser = ({
   accountId,
-}: Readonly<{ accountId: string }>) => {
+  conversationId,
+}: Readonly<{ accountId: string; conversationId?: string }>) => {
   const { comments, isLoading, chatbotPrompt, chatbotAvatar } = useConversation(
-    { accountId },
+    { accountId, conversationId },
   );
 
   return (

--- a/src/modules/comment/Conversations.tsx
+++ b/src/modules/comment/Conversations.tsx
@@ -9,6 +9,7 @@ import {
   TableBody,
   TableCell,
   TableContainer,
+  TableHead,
   TableRow,
   Typography,
 } from '@mui/material';
@@ -35,7 +36,6 @@ const useConversations = () => {
   if (messages) {
     const conversations = groupBy(messages, (c) => c.data.conversationId);
     return Object.entries(conversations)
-      .toSorted((a, b) => (a[0] > b[0] ? 1 : -1))
       .map(([id, m]) => {
         const sortedMessages = m.toSorted((a, b) =>
           a.createdAt > b.createdAt ? 1 : -1,
@@ -46,6 +46,7 @@ const useConversations = () => {
           id,
           name: sortedMessages[0].data.content,
           messages: m,
+          lastMessageCreatedAt: creationDate ?? '',
           lastMessageDate: creationDate
             ? intlFormat(
                 creationDate,
@@ -60,7 +61,10 @@ const useConversations = () => {
               )
             : '',
         };
-      });
+      })
+      .toSorted((a, b) =>
+        a.lastMessageCreatedAt < b.lastMessageCreatedAt ? 1 : -1,
+      );
   }
 
   return [];
@@ -88,7 +92,13 @@ export function Conversations({
         <Stack gap={3}>
           <ChatbotHeader avatar={chatbotAvatar} name={chatbotName} />
           <TableContainer data-cy={TABLE_VIEW_TABLE_CYPRESS}>
-            <Table aria-label="conversations table">
+            <Table aria-label={t('List of Conversations')}>
+              {/* hide headers visually */}
+              <TableHead sx={{ position: 'absolute', clip: 'rect(0 0 0 0)' }}>
+                <TableCell>{t('Conversation Name')}</TableCell>
+                <TableCell>{t('Last Message Date')}</TableCell>
+                <TableCell>{t('Actions')}</TableCell>
+              </TableHead>
               <TableBody data-cy={TABLE_VIEW_BODY_USERS_CYPRESS}>
                 {conversations.map((c) => (
                   <TableRow key={c.id}>
@@ -110,6 +120,7 @@ export function Conversations({
                     </TableCell>
                     <TableCell align="right">
                       <IconButton
+                        title={t('Open conversation')}
                         onClick={() => {
                           console.debug(`Open conversation ${c.id}`);
                           onSelect(c.id);

--- a/src/modules/comment/Conversations.tsx
+++ b/src/modules/comment/Conversations.tsx
@@ -1,0 +1,139 @@
+import { useTranslation } from 'react-i18next';
+
+import {
+  Button,
+  Container,
+  IconButton,
+  Stack,
+  Table,
+  TableBody,
+  TableCell,
+  TableContainer,
+  TableRow,
+  Typography,
+} from '@mui/material';
+
+import { intlFormat } from 'date-fns';
+import groupBy from 'lodash.groupby';
+import { MessagesSquareIcon, PlusIcon } from 'lucide-react';
+import { v4 } from 'uuid';
+
+import type { CommentData } from '@/config/appData';
+import { hooks } from '@/config/queryClient';
+import {
+  TABLE_VIEW_BODY_USERS_CYPRESS,
+  TABLE_VIEW_TABLE_CYPRESS,
+} from '@/config/selectors';
+
+import { ChatbotContainer } from './ChatbotContainer';
+import ChatbotHeader from './ChatbotHeader';
+
+const useConversations = () => {
+  const { i18n } = useTranslation();
+  const { data: messages = [] } = hooks.useAppData<CommentData>();
+
+  if (messages) {
+    const conversations = groupBy(messages, (c) => c.data.conversationId);
+    return Object.entries(conversations)
+      .toSorted((a, b) => (a[0] > b[0] ? 1 : -1))
+      .map(([id, m]) => {
+        const sortedMessages = m.toSorted((a, b) =>
+          a.createdAt > b.createdAt ? 1 : -1,
+        );
+        const creationDate = sortedMessages.at(-1)?.createdAt;
+
+        return {
+          id,
+          name: sortedMessages[0].data.content,
+          messages: m,
+          lastMessageDate: creationDate
+            ? intlFormat(
+                creationDate,
+                {
+                  year: 'numeric',
+                  month: 'long',
+                  day: 'numeric',
+                  hour: 'numeric',
+                  minute: 'numeric',
+                },
+                { locale: i18n.language },
+              )
+            : '',
+        };
+      });
+  }
+
+  return [];
+};
+
+export function Conversations({
+  chatbotAvatar,
+  chatbotName,
+  onSelect,
+}: Readonly<{
+  chatbotAvatar?: Blob;
+  chatbotName: string;
+  onSelect: (id: string) => void;
+}>) {
+  const { t } = useTranslation();
+  const conversations = useConversations();
+
+  const startNewConversation = () => {
+    onSelect(v4());
+  };
+
+  return (
+    <Container>
+      <ChatbotContainer>
+        <Stack gap={3}>
+          <ChatbotHeader avatar={chatbotAvatar} name={chatbotName} />
+          <TableContainer data-cy={TABLE_VIEW_TABLE_CYPRESS}>
+            <Table aria-label="conversations table">
+              <TableBody data-cy={TABLE_VIEW_BODY_USERS_CYPRESS}>
+                {conversations.map((c) => (
+                  <TableRow key={c.id}>
+                    <TableCell>
+                      <Typography
+                        variant="body1"
+                        fontWeight="bold"
+                        noWrap
+                        maxWidth={200}
+                        title={c.name}
+                      >
+                        {c.name}
+                      </Typography>
+                    </TableCell>
+                    <TableCell>
+                      <Typography variant="body2">
+                        {c.lastMessageDate}
+                      </Typography>
+                    </TableCell>
+                    <TableCell align="right">
+                      <IconButton
+                        onClick={() => {
+                          console.debug(`Open conversation ${c.id}`);
+                          onSelect(c.id);
+                        }}
+                      >
+                        <MessagesSquareIcon />
+                      </IconButton>
+                    </TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          </TableContainer>
+          <Stack alignItems="center">
+            <Button
+              variant="contained"
+              startIcon={<PlusIcon />}
+              onClick={startNewConversation}
+            >
+              {t('New conversation')}
+            </Button>
+          </Stack>
+        </Stack>
+      </ChatbotContainer>
+    </Container>
+  );
+}

--- a/src/modules/common/useAskChatbot.tsx
+++ b/src/modules/common/useAskChatbot.tsx
@@ -13,7 +13,13 @@ import { mutations } from '@/config/queryClient';
  * @param chatbotPrompt settings of the chatbot with cue and initial prompt
  * @returns generateChatbotAnswer function
  */
-export const useAskChatbot = (chatbotPrompt: ChatbotPromptSettings) => {
+export const useAskChatbot = ({
+  chatbotPrompt,
+  conversationId,
+}: {
+  chatbotPrompt: ChatbotPromptSettings;
+  conversationId?: string;
+}) => {
   const { mutateAsync: postAppDataAsync, isLoading: isPostAppDataLoading } =
     mutations.usePostAppData();
 
@@ -49,13 +55,14 @@ export const useAskChatbot = (chatbotPrompt: ChatbotPromptSettings) => {
           data: {
             parent: userMessageId,
             content: chatBotRes.completion,
+            conversationId,
           },
           type: AppDataTypes.BotComment,
         });
 
         // save action for asking the chatbot
-        await postAction({
-          data: { prompt, userMessageId },
+        postAction({
+          data: { prompt, userMessageId, conversationId },
           type: AppActionsType.AskChatbot,
         });
       } catch (e) {
@@ -68,6 +75,7 @@ export const useAskChatbot = (chatbotPrompt: ChatbotPromptSettings) => {
       postAction,
       postAppDataAsync,
       postChatBotAsync,
+      conversationId,
     ],
   );
 

--- a/src/modules/common/useChatbotPrompt.tsx
+++ b/src/modules/common/useChatbotPrompt.tsx
@@ -1,0 +1,13 @@
+import { ChatbotPromptSettings, SettingsKeys } from '@/config/appSetting';
+import { hooks } from '@/config/queryClient';
+
+export const useChatbotPrompt = () => {
+  const { data: chatbotPromptSettings, isLoading } =
+    hooks.useAppSettings<ChatbotPromptSettings>({
+      name: SettingsKeys.ChatbotPrompt,
+    });
+
+  const chatbotPrompt = chatbotPromptSettings?.[0]?.data;
+
+  return { data: chatbotPrompt, isLoading };
+};

--- a/src/modules/common/useSendMessage.tsx
+++ b/src/modules/common/useSendMessage.tsx
@@ -8,7 +8,13 @@ import { hooks, mutations } from '@/config/queryClient';
  * Create a function that save an app data with the user message
  * @returns sendMessage function
  */
-export const useSendMessage = ({ chatbotCue }: { chatbotCue?: string }) => {
+export const useSendMessage = ({
+  chatbotCue,
+  conversationId,
+}: {
+  chatbotCue?: string;
+  conversationId?: string;
+}) => {
   const { data: comments } = hooks.useAppData<CommentData>();
   const { mutateAsync: postAppDataAsync, isLoading } =
     mutations.usePostAppData();
@@ -21,6 +27,7 @@ export const useSendMessage = ({ chatbotCue }: { chatbotCue?: string }) => {
         await postAppDataAsync({
           data: {
             content: chatbotCue,
+            conversationId,
           },
           type: AppDataTypes.BotComment,
         });
@@ -29,18 +36,25 @@ export const useSendMessage = ({ chatbotCue }: { chatbotCue?: string }) => {
       const userMessage = await postAppDataAsync({
         data: {
           content: newUserComment,
+          conversationId,
         },
         type: AppDataTypes.UserComment,
       });
 
       await postAppActionAsync({
         type: AppActionsType.Reply,
-        data: { content: newUserComment },
+        data: { content: newUserComment, conversationId },
       });
 
       return userMessage;
     },
-    [comments?.length, chatbotCue, postAppDataAsync, postAppActionAsync],
+    [
+      comments?.length,
+      chatbotCue,
+      postAppDataAsync,
+      postAppActionAsync,
+      conversationId,
+    ],
   );
 
   return { sendMessage, isLoading };

--- a/src/modules/common/useSendMessageAndAskChatbot.ts
+++ b/src/modules/common/useSendMessageAndAskChatbot.ts
@@ -12,14 +12,19 @@ import { useSendMessage } from './useSendMessage';
 export const useSendMessageAndAskChatbot = ({
   chatbotPrompt,
   onSend,
+  conversationId,
 }: {
   chatbotPrompt: ChatbotPromptSettings;
   onSend?: () => void;
+  conversationId?: string;
 }) => {
-  const { generateChatbotAnswer, isLoading: askChatbotLoading } =
-    useAskChatbot(chatbotPrompt);
-  const { sendMessage, isLoading: sendMessageLoading } =
-    useSendMessage(chatbotPrompt);
+  const { generateChatbotAnswer, isLoading: askChatbotLoading } = useAskChatbot(
+    { chatbotPrompt, conversationId },
+  );
+  const { sendMessage, isLoading: sendMessageLoading } = useSendMessage({
+    chatbotCue: chatbotPrompt.chatbotCue,
+    conversationId,
+  });
 
   const send = useCallback(
     async (newUserComment: string) => {

--- a/src/modules/main/AdminView.tsx
+++ b/src/modules/main/AdminView.tsx
@@ -45,7 +45,7 @@ function AdminView(): JSX.Element {
     });
 
   return (
-    <Box data-cy={BUILDER_VIEW_CY}>
+    <Box data-cy={BUILDER_VIEW_CY} minHeight={500}>
       <TabContext value={activeTab}>
         <TabList
           textColor="secondary"

--- a/src/modules/main/ConversationsView.tsx
+++ b/src/modules/main/ConversationsView.tsx
@@ -1,4 +1,4 @@
-import type { ReactElement } from 'react';
+import type { ReactNode } from 'react';
 import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
@@ -8,12 +8,13 @@ import {
   Table,
   TableBody,
   TableCell,
-  TableContainer,
   TableHead,
   TableRow,
-  useTheme,
 } from '@mui/material';
 
+import { AppData } from '@graasp/sdk';
+
+import { intlFormat } from 'date-fns';
 import groupBy from 'lodash.groupby';
 import { MessagesSquare, XIcon } from 'lucide-react';
 
@@ -25,7 +26,6 @@ import {
   TABLE_VIEW_NB_COMMENTS_CELL_CYPRESS,
   TABLE_VIEW_OPEN_REVIEW_BUTTON_CYPRESS,
   TABLE_VIEW_REVIEW_DIALOG_CLOSE_BUTTON_CYPRESS,
-  TABLE_VIEW_TABLE_CYPRESS,
   TABLE_VIEW_USERNAME_CELL_CYPRESS,
   TABLE_VIEW_USER_REVIEW_DIALOG_CYPRESS,
   TABLE_VIEW_VIEW_COMMENTS_CELL_CYPRESS,
@@ -33,83 +33,162 @@ import {
 } from '@/config/selectors';
 import { ANONYMOUS_USER } from '@/constants';
 import CustomDialog from '@/modules/common/CustomDialog';
-import { getOrphans } from '@/utils/comments';
 
 import { ConversationForUser } from '../comment/ConversationForUser';
 import DownloadButtons from '../settings/DownloadButtons';
 import OrphanComments from '../settings/OrphanComments';
 
-const DEFAULT_CURRENT_USER = {
-  name: ANONYMOUS_USER,
-  id: '',
+type ConversationsPerUser = {
+  account: {
+    id: string;
+    name: string;
+  };
+  conversations: {
+    id: string;
+    lastMessageAt: string;
+    messages: AppData<CommentData>[];
+  }[];
+};
+
+const useConversationsPerUser = (): ConversationsPerUser[] => {
+  const { i18n } = useTranslation();
+  const { data: comments = [] } = hooks.useAppData<CommentData>();
+
+  const commentsByUsers = Object.entries(
+    groupBy(comments, ({ account }) => account?.id),
+  );
+
+  const conversationsByUsers = commentsByUsers.map(([accountId, messages]) => ({
+    account: {
+      id: accountId,
+      name: messages[0].account?.name ?? ANONYMOUS_USER,
+    },
+
+    conversations: Object.entries(
+      groupBy(messages, (m) => m.data.conversationId),
+    ).map(([id, convMessages]) => {
+      // get last message date
+      const sortedMessages = convMessages.toSorted((a, b) =>
+        a.createdAt > b.createdAt ? 1 : -1,
+      );
+      const lastMessageAt = sortedMessages.at(-1)?.createdAt;
+
+      return {
+        id,
+        lastMessageAt: lastMessageAt
+          ? intlFormat(
+              lastMessageAt,
+              {
+                year: 'numeric',
+                month: 'long',
+                day: 'numeric',
+                hour: 'numeric',
+                minute: 'numeric',
+              },
+              { locale: i18n.language },
+            )
+          : '',
+        messages: convMessages,
+      };
+    }),
+  }));
+
+  return conversationsByUsers.toSorted((a, b) =>
+    a.account.name > b.account.name ? 1 : -1,
+  );
+};
+const ConversationsTable = ({
+  viewConversation,
+}: {
+  viewConversation: (args: {
+    account: ConversationsPerUser['account'];
+    id: string;
+  }) => void;
+}): ReactNode[] | ReactNode => {
+  const conversationsPerUser = useConversationsPerUser();
+  const { t } = useTranslation();
+
+  // nonOrphanComments is undefined or, is an empty list -> there are not resources to display
+  if (!conversationsPerUser) {
+    // show that there are no comments available
+    return (
+      <TableRow>
+        <TableCell
+          data-cy={TABLE_NO_COMMENTS_CYPRESS}
+          colSpan={3}
+          align="center"
+        >
+          {t('NO_COMMENTS_PLACEHOLDER')}
+        </TableCell>
+      </TableRow>
+    );
+  }
+
+  return conversationsPerUser.map(({ account, conversations }) => {
+    return (
+      <TableRow key={account.id} data-cy={tableRowUserCypress(account.id)}>
+        <TableCell data-cy={TABLE_VIEW_USERNAME_CELL_CYPRESS}>
+          {account.name}
+        </TableCell>
+        <TableCell data-cy={TABLE_VIEW_NB_COMMENTS_CELL_CYPRESS}>
+          <Table>
+            <TableHead>
+              <TableRow>
+                <TableCell>{t('Last message')}</TableCell>
+                <TableCell>{t('Number of messages')}</TableCell>
+                <TableCell></TableCell>
+              </TableRow>
+            </TableHead>
+            {conversations.map(({ id, lastMessageAt, messages }) => (
+              <TableRow key={id}>
+                <TableCell>{lastMessageAt}</TableCell>
+                <TableCell>{messages.length}</TableCell>
+                <TableCell
+                  align="right"
+                  data-cy={TABLE_VIEW_VIEW_COMMENTS_CELL_CYPRESS}
+                >
+                  <IconButton
+                    data-cy={TABLE_VIEW_OPEN_REVIEW_BUTTON_CYPRESS}
+                    onClick={() => viewConversation({ account, id })}
+                    color="primary"
+                  >
+                    <MessagesSquare />
+                  </IconButton>
+                </TableCell>
+              </TableRow>
+            ))}
+          </Table>
+        </TableCell>
+      </TableRow>
+    );
+  });
 };
 
 function ConversationsView() {
   const { t } = useTranslation();
-  const theme = useTheme();
   const [openCommentView, setOpenCommentView] = useState(false);
-  const [currentUser, setCurrentUser] = useState(DEFAULT_CURRENT_USER);
-  const { data: { members } = { members: [] } } = hooks.useAppContext();
+  const [selectedConversation, setSelectedConversation] = useState<null | {
+    account: ConversationsPerUser['account'];
+    conversationId: string;
+  }>(null);
   const { data: comments = [] } = hooks.useAppData<CommentData>();
 
-  const renderTableBody = (): ReactElement[] | ReactElement | null => {
-    const orphansId = getOrphans(comments).map((c) => c.id);
-    const nonOrphanComments = comments?.filter(
-      (c) => !orphansId.includes(c.id),
-    );
-    // nonOrphanComments is undefined or, is an empty list -> there are not resources to display
-    if (
-      !nonOrphanComments ||
-      nonOrphanComments.length === 0 // oxlint-disable-line eslint/yoda
-    ) {
-      // show that there are no comments available
-      return (
-        <TableRow>
-          <TableCell
-            data-cy={TABLE_NO_COMMENTS_CYPRESS}
-            colSpan={3}
-            align="center"
-          >
-            {t('NO_COMMENTS_PLACEHOLDER')}
-          </TableCell>
-        </TableRow>
-      );
-    }
-    const commentsByUsers = Object.entries(
-      groupBy(nonOrphanComments, ({ account }) => account.id),
-    );
-    return commentsByUsers.map(([userId, userComments]) => {
-      const userName =
-        members.find(({ id }) => id === userId)?.name || ANONYMOUS_USER;
-      return (
-        <TableRow key={userId} data-cy={tableRowUserCypress(userId)}>
-          <TableCell data-cy={TABLE_VIEW_USERNAME_CELL_CYPRESS}>
-            {userName}
-          </TableCell>
-          <TableCell data-cy={TABLE_VIEW_NB_COMMENTS_CELL_CYPRESS}>
-            <div>{userComments.length}</div>
-          </TableCell>
-          <TableCell data-cy={TABLE_VIEW_VIEW_COMMENTS_CELL_CYPRESS}>
-            <IconButton
-              data-cy={TABLE_VIEW_OPEN_REVIEW_BUTTON_CYPRESS}
-              onClick={() => {
-                setCurrentUser({
-                  name: userName,
-                  id: userId,
-                });
-                setOpenCommentView(true);
-              }}
-            >
-              <MessagesSquare color={theme.palette.primary.main} />
-            </IconButton>
-          </TableCell>
-        </TableRow>
-      );
+  const viewConversation = ({
+    account,
+    id,
+  }: {
+    account: ConversationsPerUser['account'];
+    id: string;
+  }) => {
+    setSelectedConversation({
+      account,
+      conversationId: id,
     });
+    setOpenCommentView(true);
   };
 
   const onCloseDialog = (): void => {
-    setCurrentUser(DEFAULT_CURRENT_USER);
+    setSelectedConversation(null);
     setOpenCommentView(false);
   };
 
@@ -117,36 +196,34 @@ function ConversationsView() {
     <Stack spacing={2}>
       <DownloadButtons />
       <OrphanComments comments={comments} />
-      <TableContainer data-cy={TABLE_VIEW_TABLE_CYPRESS}>
-        <Table aria-label="student table">
-          <TableHead>
-            <TableRow>
-              <TableCell>{t('NAME_COLUMN_HEADER')}</TableCell>
-              <TableCell>{t('MESSAGE_NUMBER_COLUMN_HEADER')}</TableCell>
-              <TableCell>{t('VIEW_CHAT_COLUMN_HEADER')}</TableCell>
-            </TableRow>
-          </TableHead>
-          <TableBody data-cy={TABLE_VIEW_BODY_USERS_CYPRESS}>
-            {renderTableBody()}
-          </TableBody>
-        </Table>
-      </TableContainer>
-      <CustomDialog
-        dataCy={TABLE_VIEW_USER_REVIEW_DIALOG_CYPRESS}
-        open={openCommentView}
-        maxWidth="lg"
-        title={t('DISCUSSION_DIALOG_TITLE', { user: currentUser.name })}
-        onClose={onCloseDialog}
-      >
-        <ConversationForUser accountId={currentUser.id} />
-        <IconButton
-          data-cy={TABLE_VIEW_REVIEW_DIALOG_CLOSE_BUTTON_CYPRESS}
-          onClick={onCloseDialog}
-          sx={{ position: 'absolute', top: 0, right: 0, m: 1 }}
+      <Table size="small" aria-label="conversations per user table">
+        <TableBody data-cy={TABLE_VIEW_BODY_USERS_CYPRESS}>
+          <ConversationsTable viewConversation={viewConversation} />
+        </TableBody>
+      </Table>
+      {selectedConversation && (
+        <CustomDialog
+          dataCy={TABLE_VIEW_USER_REVIEW_DIALOG_CYPRESS}
+          open={openCommentView}
+          maxWidth="lg"
+          title={t('DISCUSSION_DIALOG_TITLE', {
+            user: selectedConversation.account.name,
+          })}
+          onClose={onCloseDialog}
         >
-          <XIcon />
-        </IconButton>
-      </CustomDialog>
+          <ConversationForUser
+            accountId={selectedConversation.account.id}
+            conversationId={selectedConversation.conversationId}
+          />
+          <IconButton
+            data-cy={TABLE_VIEW_REVIEW_DIALOG_CLOSE_BUTTON_CYPRESS}
+            onClick={onCloseDialog}
+            sx={{ position: 'absolute', top: 0, right: 0, m: 1 }}
+          >
+            <XIcon />
+          </IconButton>
+        </CustomDialog>
+      )}
     </Stack>
   );
 }

--- a/src/modules/main/PlayerView.tsx
+++ b/src/modules/main/PlayerView.tsx
@@ -1,34 +1,84 @@
+import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
-import { Typography } from '@mui/material';
+import { Button, Skeleton, Stack, Typography } from '@mui/material';
 
 import { useLocalContext } from '@graasp/apps-query-client';
 
+import { ArrowLeftIcon } from 'lucide-react';
+
+import { ChatbotContainer } from '../comment/ChatbotContainer';
 import Conversation from '../comment/Conversation';
+import { Conversations } from '../comment/Conversations';
+import ChatbotAvatar from '../common/ChatbotAvatar';
 import { useConversation } from '../common/useConversation';
 
 function PlayerView(): JSX.Element {
   const { t } = useTranslation();
   const { accountId } = useLocalContext();
+  // currently selected conversation id
+  // null means no conversation is selected
+  // the string 'undefined' selects the legacy conversation (no id attached)
+  const [selectedConversationId, setSelectedConversationId] = useState<
+    null | string
+  >(null);
   const { chatbotPrompt, comments, isLoading, suggestions, chatbotAvatar } =
     useConversation({
       accountId,
       showSuggestions: true,
+      conversationId: selectedConversationId,
     });
 
   if (!accountId) {
     return <Typography>{t('SIGN_OUT_ALERT')}</Typography>;
   }
 
+  if (chatbotPrompt && selectedConversationId) {
+    return (
+      <>
+        <Conversation
+          mode="write"
+          isLoading={isLoading}
+          comments={comments}
+          chatbotPrompt={chatbotPrompt}
+          chatbotAvatar={chatbotAvatar}
+          suggestions={suggestions}
+          conversationId={selectedConversationId}
+        />
+        <Stack alignItems="center" mt={2}>
+          <Button
+            variant="outlined"
+            startIcon={<ArrowLeftIcon />}
+            onClick={() => {
+              setSelectedConversationId(null);
+            }}
+          >
+            {t('Go back to conversations')}
+          </Button>
+        </Stack>
+      </>
+    );
+  }
+
+  if (chatbotPrompt) {
+    const { chatbotName } = chatbotPrompt;
+    return (
+      <Conversations
+        chatbotAvatar={chatbotAvatar}
+        chatbotName={chatbotName}
+        onSelect={setSelectedConversationId}
+      />
+    );
+  }
+
   return (
-    <Conversation
-      mode="write"
-      isLoading={isLoading}
-      comments={comments}
-      chatbotPrompt={chatbotPrompt}
-      chatbotAvatar={chatbotAvatar}
-      suggestions={suggestions}
-    />
+    <ChatbotContainer>
+      <Stack mx={2} alignItems="center">
+        <ChatbotAvatar isLoading />
+        <Skeleton height={50} width="100%" />
+        <Skeleton height={300} width="100%" />
+      </Stack>
+    </ChatbotContainer>
   );
 }
 export default PlayerView;


### PR DESCRIPTION
To resolve the problem of "clearing", I added conversations.

Added the concept (back) of conversations. I added a `conversationId` to the app data's data.

The user will be able to create a conversation and see all its conversations that will have the same prompt and suggestion as in the settings. The title is the first message.

<img width="870" height="465" alt="Screenshot 2026-02-17 at 19 11 15" src="https://github.com/user-attachments/assets/602afb65-4394-4641-bec8-819cf36cd17c" />


https://github.com/user-attachments/assets/326952a7-02b9-43fc-865c-125fd0b7d2bb

TODO

- [ ] write / fix tests

close #387 